### PR TITLE
Added Support For Linux On Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ os:
   - linux
   - osx
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - node
   - '9'


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/has-values/builds/209185759
Please have a look.

Regards,
ujjwal